### PR TITLE
feat/ added a route to change url, to avoid restarting the app and ch…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,49 @@
-# roker
+<h1 align="center"><code>roker</code></h1>
+
+<div align="center">
+  <sub>Created by <a href="https://github.com/urbanishimwe">Urban Ishimwe</a></sub>
+</div>
+
 Route ngrok URL to static URL
 
+
+## Why
+
 "I am overwhelmed by configuring URL on API service like Slack everytime I start my Ngrok server".
-then this might be solution.
+Then, this might be the solution.
 
-## how??
-- **Fork this repository**
-- **create account on heroku**
+## How?
+1. Fork this repository
+2. create an account on Heroku
 
-## configuration
-- **deploy the forked version on your heroku**
-- **config your URL by setting heroku enviroment:** `URL`=`secure-ngrok-url`
-- **you might need to restart your app everytime you change this environment**
+## Setup
+1. deploy the forked version on your Heroku
+2. Config your URL by setting an heroku environment: `URL`=`secure-ngrok-url`
+3. Config your SECRET by setting an heroku environment variable: e.g `SECRET`=`IFFEnGFS4H`
 
-## final
-`instead of using ngrok link` just use your `heroku link`
+*you might need to restart your app everytime you change this environments*
 
-## contributions
-are very welcome 🙏🙏🙏🙏
+## Final
+
+Now, you can just use your Heroku link that will forward to your ngrok dynamic address.
+
+If you want to change your url without changing the URL env variable and restarting your app. You can use the route:
+
+```
+https://HEROKU_URL/update_ngrok&secret=SECRET&url=NGROK_URL
+```
+
+
+You can, for example, open with your browser: https://myheroku/update_ngrok&secret=IFFEnGFS4H&url=https://b1dd4477.ngrok.io/
+
+or 
+From your terminal
+
+```bash
+curl "your_heroku/update_ngrok?secret=IFFEnGFS4H&url=https://b1dd4477.ngrok.io"
+```
+
+## Contributions
+
+Feel free to contribute, PR and issues are very welcome 🙏🙏🙏🙏
 

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func changeURL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	URL = url
-	fmt.Printf("now URL forward to: %s\n", url)
+	log.Printf("now URL forward to: %s\n", url)
 
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, "Success")

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -8,9 +9,14 @@ import (
 	"os"
 )
 
+// URL stores your ngrok dynamic address
+var (
+	URL    = os.Getenv("URL")
+	secret = os.Getenv("SECRET")
+)
+
 // Serve a reverse proxy for a given url
 func serveReverseProxy(target string, res http.ResponseWriter, req *http.Request) {
-	// parse the url
 	url, _ := url.Parse(target)
 
 	// create the reverse proxy
@@ -24,14 +30,36 @@ func serveReverseProxy(target string, res http.ResponseWriter, req *http.Request
 	proxy.ServeHTTP(res, req)
 }
 
-// Given a request send it to the appropriate url
-func handleRequestAndRedirect(res http.ResponseWriter, req *http.Request) {
-	log.Println("from ", req.RemoteAddr)
-	url := os.Getenv("URL")
-	serveReverseProxy(url, res, req)
+func handleRequestAndRedirect(w http.ResponseWriter, r *http.Request) {
+	log.Println("from ", r.RemoteAddr)
+	serveReverseProxy(URL, w, r)
 }
 
-// Get env var or default
+func changeURL(w http.ResponseWriter, r *http.Request) {
+	log.Println("from ", r.RemoteAddr)
+
+	if err := r.ParseForm(); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Internal error while Parsing")
+		return
+	}
+
+	key := r.URL.Query().Get("secret")
+	url := r.URL.Query().Get("url")
+
+	if key != secret {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprintf(w, "Forbidden")
+		return
+	}
+
+	URL = url
+	fmt.Printf("now URL forward to: %s\n", url)
+
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "Success")
+}
+
 func getEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
@@ -44,15 +72,11 @@ func getListenAddress() string {
 	return ":" + port
 }
 
-func logSetup() {
-	url := os.Getenv("URL")
-	log.Printf("Server will run on %s\n", getListenAddress())
-	log.Printf("Redirecting to a url: %s\n", url)
-}
-
 func main() {
-	logSetup()
+	log.Printf("Server will run on %s\n", getListenAddress())
+	log.Printf("Redirecting to a url: %s\n", URL)
 
+	http.HandleFunc("/update_ngrok", changeURL)
 	http.HandleFunc("/", handleRequestAndRedirect)
 	if err := http.ListenAndServe(getListenAddress(), nil); err != nil {
 		log.Panicln("server error", err.Error())


### PR DESCRIPTION
Hello!

I proposed this Pull request, regarding the fact you need to change your Heroku ENV variable and restarting your app every time your ngrok address change.

I added a route /update_ngrok protected with a key you have to specify in your Heroku ENV

It allows you to change your URL by just getting the page: `https://HEROKU_URL/update_ngrok&secret=SECRET&url=NGROK_URL`, either by your browser or a simple curl.

I also edit a little bit of your README to mention this feature.